### PR TITLE
temporary fix for the error computing the correlation of BSP

### DIFF
--- a/Python/scoreCommon.py
+++ b/Python/scoreCommon.py
@@ -132,7 +132,8 @@ def computePOT(truthMatrix, testMatrix):
     for i in range(n):
         truthVec=(truthMatrix[:,i])
         testVec=(testMatrix[:,i])
-        sumCorrelation= sumCorrelation + scipy.stats.pearsonr(truthVec, testVec)[0]
+		if (truthVec != truthVec[0]) & (testVec != testVec[0])
+        	sumCorrelation= sumCorrelation + scipy.stats.pearsonr(truthVec, testVec)[0]
         Error_t=math.pow(np.linalg.norm(truthVec-testVec),2)
         magtruthVect = magnitudesqure(truthVec)
         sumError= sumError + Error_t/magtruthVect


### PR DESCRIPTION
Applied a temporary patch for the error.

When Computing the correlation between BSPs, the code uses persons correlation.
By default, these metric divides by the vector minus its mean, which is 0 if the vector is constant.

Thus, when there is a column of constant value, the code breaks.

I have temporarily assumed that the correlation is 0 when one of the vectors is constant…. hopefully it will work